### PR TITLE
Fix GitHub Actions workflow by resolving webpack config errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gpx-traces-website",
   "version": "1.0.0",
   "description": "A website to display GPX traces on an interactive map",
-  "main": "index.js",
+  "main": "scripts/map.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
     "start": "webpack serve --config webpack.config.js"

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,3 +1,6 @@
+import L from 'leaflet';
+import xml2js from 'xml2js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const map = L.map('map').setView([51.505, -0.09], 13);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 
 module.exports = {
-  entry: './index.js',
+  entry: './scripts/map.js',
+  mode: 'production',
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist')


### PR DESCRIPTION
Update webpack configuration and package.json to resolve module errors and set mode to production.

* **webpack.config.js**
  - Change entry point to `./scripts/map.js`
  - Add `mode` property and set it to 'production'

* **package.json**
  - Set `main` property to `scripts/map.js`

* **scripts/map.js**
  - Import `leaflet` library
  - Import `xml2js` library

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/3?shareId=d35cd9ad-4914-4958-b36f-7de6f41c116d).