### PR TITLE
Fix Github Action errors for resolve.fallback with webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,5 +21,12 @@ module.exports = {
         use: ['style-loader', 'css-loader']
       }
     ]
+  },
+  resolve: {
+    fallback: {
+      stream: false,
+      buffer: false,
+      timers: false
+    }
   }
 };


### PR DESCRIPTION
Add `resolve.fallback` configuration to `webpack.config.js` to address missing polyfills for node.js core modules.

* Add `resolve.fallback` configuration for `stream`, `buffer`, and `timers` in `webpack.config.js`
* Set `resolve.fallback` for `stream` to `false`
* Set `resolve.fallback` for `buffer` to `false`
* Set `resolve.fallback` for `timers` to `false`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/6?shareId=e8e07704-0110-4ef8-84fc-86debecf3164).