### PR TITLE
Fix GitHub Action deploy failed with remote: Permission to statnmap/gpx-traces-website.git denied to github-actions[bot]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
Update GitHub Actions workflow to use personal access token for deployment.

* Change the `Deploy to GitHub Pages` step in `.github/workflows/deploy.yml` to use the `PERSONAL_ACCESS_TOKEN` secret instead of `GITHUB_TOKEN`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/7?shareId=4d4dabe4-8ff2-45b2-a849-00269e240ae0).