### PR TITLE
Fix syntaxerror during website build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,10 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         use: {
-          loader: 'babel-loader'
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env']
+          }
         }
       },
       {


### PR DESCRIPTION
Fix the SyntaxError caused by the '??=' token during the website build.

* Update `webpack.config.js` to use `babel-loader` with `@babel/preset-env` preset
  - Add `options` with `presets: ['@babel/preset-env']` to `babel-loader` configuration for `.js` files

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/9?shareId=09e82ac8-dcf2-4d17-90b5-9ee4b4c4381c).