### PR TITLE
Fix website build error due to node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
-        "babel-loader": "^8.2.2",
+        "babel-loader": "^8.4.1",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^5.0.1",
         "style-loader": "^2.0.0",
@@ -2179,6 +2179,7 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
       "integrity": "sha512-nXzRChX+Z1GoE6yWavBQg6jDslyFF3SDjl2paADuoQtQW10JqShJt62R6eJQ5m/pjJFDT8xgKIWSP85OY8eXeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-cache-dir": "^3.3.1",
         "loader-utils": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
-    "babel-loader": "^8.2.2",
+    "babel-loader": "^8.4.1",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^5.0.1",
     "style-loader": "^2.0.0",


### PR DESCRIPTION
Update Node.js version to fix website build error.

* **Update Node.js version in `.github/workflows/deploy.yml`**
  - Change `node-version` from '14' to '16' to support the nullish coalescing assignment operator (`??=`).

* **Update `babel-loader` version in `package-lock.json` and `package.json`**
  - Change `babel-loader` version from `^8.2.2` to `^8.4.1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/10?shareId=b0fdfd66-df09-4a34-9d9b-5e1aeae1d5a4).