### PR TITLE
Fix GPX trace hover and click events

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -25,6 +25,18 @@ document.addEventListener('DOMContentLoaded', () => {
           link.click();
         });
 
+        polyline.on('mouseover', (e) => {
+          const popup = L.popup()
+            .setLatLng(e.latlng)
+            .setContent(trace.name)
+            .openOn(map);
+          polyline.bindPopup(popup);
+        });
+
+        polyline.on('mouseout', () => {
+          map.closePopup();
+        });
+
         if (!traceLayers[trace.category]) {
           traceLayers[trace.category] = [];
         }

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -20,8 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         polyline.on('click', () => {
           const link = document.createElement('a');
-          link.href = `gpx-files/${trace.name}.gpx`;
-          link.download = `${trace.name}.gpx`;
+          link.href = `gpx-files/${sanitizeFileName(trace.name)}.gpx`;
+          link.download = `${sanitizeFileName(trace.name)}.gpx`;
           link.click();
         });
 
@@ -67,5 +67,9 @@ document.addEventListener('DOMContentLoaded', () => {
       default:
         return 'gray';
     }
+  }
+
+  function sanitizeFileName(fileName) {
+    return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
   }
 });

--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -32,7 +32,7 @@ function processGpxFiles() {
             }
 
             const trace = {
-              name: result.gpx.trk[0].name[0],
+              name: sanitizeFileName(result.gpx.trk[0].name[0]),
               category: getCategory(result.gpx.trk[0].name[0]),
               coordinates: getCoordinates(result.gpx.trk[0].trkseg[0].trkpt)
             };
@@ -67,6 +67,10 @@ function getCoordinates(trkpts) {
     lat: parseFloat(trkpt.$.lat),
     lon: parseFloat(trkpt.$.lon)
   }));
+}
+
+function sanitizeFileName(fileName) {
+  return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 }
 
 processGpxFiles();


### PR DESCRIPTION
Add hover event to show title of the original file and fix click event to download GPX source.

* Add `mouseover` event listener in `scripts/map.js` to display the title of the original file when hovering on the trace.
* Add `mouseout` event listener in `scripts/map.js` to hide the title when not hovering on the trace.
* Fix the click event in `scripts/map.js` to download the GPX source correctly.
* Add a function in `scripts/process-gpx.js` to sanitize GPX file names by removing or replacing special characters.
* Update the code in `scripts/process-gpx.js` to use sanitized file names consistently throughout the codebase.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/14?shareId=80784045-0beb-491a-a552-9862ad95c818).