### PR TITLE
Fix: Use GPX filename as trace.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ The repository is configured to use GitHub Actions to build and deploy the websi
 ## Deployment
 
 The static website is hosted on GitHub Pages. The repository is configured to automatically build and deploy the website using GitHub Actions whenever changes are made to the GPX files or the codebase.
+
+## Trace Name
+
+The trace name (`trace.name`) used in the application is derived from the GPX filename (without extension). Ensure the GPX filename is descriptive and includes the category to map it correctly.

--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -32,8 +32,8 @@ function processGpxFiles() {
             }
 
             const trace = {
-              name: sanitizeFileName(result.gpx.trk[0].name[0]),
-              category: getCategory(result.gpx.trk[0].name[0]),
+              name: sanitizeFileName(path.basename(file, '.gpx')),
+              category: getCategory(path.basename(file, '.gpx')),
               coordinates: getCoordinates(result.gpx.trk[0].trkseg[0].trkpt)
             };
 


### PR DESCRIPTION
Update `trace.name` to use the GPX filename without extension instead of the trace name from the GPX file content.

* **scripts/process-gpx.js**
  - Change `trace.name` to use `sanitizeFileName(path.basename(file, '.gpx'))`
  - Update `trace.category` to use `getCategory(path.basename(file, '.gpx'))`

* **README.md**
  - Add instructions specifying that the GPX filename is used as `trace.name`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/15?shareId=8c3eb037-30d1-45ed-8088-e49528222bb2).