### PR TITLE
feat: colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@
   <main>
     <div id="map"></div>
     <div id="filters">
-      <label>
+      <label style="color: blue;">
         <input type="checkbox" name="category" value="sec" checked>
         Sec
       </label>
-      <label>
+      <label style="color: green;">
         <input type="checkbox" name="category" value="humide" checked>
         Humide
       </label>
-      <label>
+      <label style="color: brown;">
         <input type="checkbox" name="category" value="boueux" checked>
         Boueux
       </label>

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -31,10 +31,12 @@ document.addEventListener('DOMContentLoaded', () => {
             .setContent(trace.name)
             .openOn(map);
           polyline.bindPopup(popup);
+          polyline.setStyle({ color: 'red' });
         });
 
         polyline.on('mouseout', () => {
           map.closePopup();
+          polyline.setStyle({ color: getColor(trace.category) });
         });
 
         if (!traceLayers[trace.category]) {


### PR DESCRIPTION
Change the color of trace to red on hover and show text of map checkboxes with the correct color.

* **scripts/map.js**
  - Add `polyline.setStyle({ color: 'red' });` in the `mouseover` event to change the color of the trace to red on hover.
  - Add `polyline.setStyle({ color: getColor(trace.category) });` in the `mouseout` event to revert the color of the trace to its original color.

* **index.html**
  - Add inline styles for the checkbox labels to display the text with the correct color for each category.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/16?shareId=c2181423-0531-42ec-95a3-1ac95e09936a).