### PR TITLE
Sanitize GPX filenames before processing

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -20,8 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         polyline.on('click', () => {
           const link = document.createElement('a');
-          link.href = `gpx-files/${sanitizeFileName(trace.name)}.gpx`;
-          link.download = `${sanitizeFileName(trace.name)}.gpx`;
+          link.href = `gpx-files/${trace.name}.gpx`;
+          link.download = `${trace.name}.gpx`;
           link.click();
         });
 
@@ -69,9 +69,5 @@ document.addEventListener('DOMContentLoaded', () => {
       default:
         return 'gray';
     }
-  }
-
-  function sanitizeFileName(fileName) {
-    return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
   }
 });

--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -7,6 +7,33 @@ const outputFilePath = path.join(__dirname, '../data/traces.json');
 
 const categories = ['sec', 'humide', 'boueux'];
 
+function sanitizeGpxFileNames() {
+  fs.readdir(gpxDir, (err, files) => {
+    if (err) {
+      console.error('Error reading GPX directory:', err);
+      return;
+    }
+
+    files.forEach((file) => {
+      if (path.extname(file) === '.gpx') {
+        const sanitizedFileName = sanitizeFileName(path.basename(file, '.gpx')) + '.gpx';
+        const oldFilePath = path.join(gpxDir, file);
+        const newFilePath = path.join(gpxDir, sanitizedFileName);
+
+        if (oldFilePath !== newFilePath) {
+          fs.rename(oldFilePath, newFilePath, (err) => {
+            if (err) {
+              console.error('Error renaming file:', err);
+            } else {
+              console.log(`Renamed ${file} to ${sanitizedFileName}`);
+            }
+          });
+        }
+      }
+    });
+  });
+}
+
 function processGpxFiles() {
   const traces = [];
 
@@ -32,7 +59,7 @@ function processGpxFiles() {
             }
 
             const trace = {
-              name: sanitizeFileName(path.basename(file, '.gpx')),
+              name: path.basename(file, '.gpx'),
               category: getCategory(path.basename(file, '.gpx')),
               coordinates: getCoordinates(result.gpx.trk[0].trkseg[0].trkpt)
             };
@@ -73,4 +100,5 @@ function sanitizeFileName(fileName) {
   return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 }
 
+sanitizeGpxFileNames();
 processGpxFiles();


### PR DESCRIPTION
Sanitize GPX filenames in the `gpx-files/` directory before processing and remove redundant sanitization function.

* Add `sanitizeGpxFileNames` function in `scripts/process-gpx.js` to sanitize GPX filenames before processing.
* Call `sanitizeGpxFileNames` function before `processGpxFiles` function in `scripts/process-gpx.js`.
* Remove `sanitizeFileName` function from `scripts/map.js`.
* Update `fetch` function in `scripts/map.js` to use sanitized filenames directly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/17?shareId=b5418bee-303a-4b78-b745-a5fd624b6d56).