### PR TITLE
Fix: separate sanitizeGpxFileNames from processGpxFiles in different js files and in actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Run sanitize script
+        run: node scripts/sanitize-gpx.js
+
       - name: Run pre-build script
         run: node scripts/process-gpx.js
 

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check Dependabot alerts
         run: npm audit
 
+      - name: Run sanitize script
+        run: node scripts/sanitize-gpx.js
+
       - name: Run pre-build script
         run: node scripts/process-gpx.js
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ To add a new GPX file, follow these steps:
 
 1. Place the new GPX file in the `gpx-files/` directory.
 2. Ensure the GPX file name includes the category ("sec", "humide", "boueux") to map it to the correct category.
-3. Run the pre-build script to process the GPX files and update the JSON file:
+3. Run the sanitize script to sanitize the GPX file names:
+   ```sh
+   node scripts/sanitize-gpx.js
+   ```
+4. Run the pre-build script to process the GPX files and update the JSON file:
    ```sh
    node scripts/process-gpx.js
    ```
@@ -32,7 +36,7 @@ The category is determined based on the GPX file name. Ensure the file name incl
 
 ## GitHub Actions
 
-The repository is configured to use GitHub Actions to build and deploy the website. The pre-build script is included in the build process to process the GPX files and update the JSON file whenever new GPX files are added or existing ones are modified.
+The repository is configured to use GitHub Actions to build and deploy the website. The sanitize script and pre-build script are included in the build process to sanitize the GPX file names, process the GPX files, and update the JSON file whenever new GPX files are added or existing ones are modified.
 
 ## Deployment
 

--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -1,38 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const xml2js = require('xml2js');
+const { sanitizeGpxFileNames } = require('./sanitize-gpx');
 
 const gpxDir = path.join(__dirname, '../gpx-files');
 const outputFilePath = path.join(__dirname, '../data/traces.json');
 
 const categories = ['sec', 'humide', 'boueux'];
-
-function sanitizeGpxFileNames() {
-  fs.readdir(gpxDir, (err, files) => {
-    if (err) {
-      console.error('Error reading GPX directory:', err);
-      return;
-    }
-
-    files.forEach((file) => {
-      if (path.extname(file) === '.gpx') {
-        const sanitizedFileName = sanitizeFileName(path.basename(file, '.gpx')) + '.gpx';
-        const oldFilePath = path.join(gpxDir, file);
-        const newFilePath = path.join(gpxDir, sanitizedFileName);
-
-        if (oldFilePath !== newFilePath) {
-          fs.rename(oldFilePath, newFilePath, (err) => {
-            if (err) {
-              console.error('Error renaming file:', err);
-            } else {
-              console.log(`Renamed ${file} to ${sanitizedFileName}`);
-            }
-          });
-        }
-      }
-    });
-  });
-}
 
 function processGpxFiles() {
   const traces = [];
@@ -94,10 +68,6 @@ function getCoordinates(trkpts) {
     lat: parseFloat(trkpt.$.lat),
     lon: parseFloat(trkpt.$.lon)
   }));
-}
-
-function sanitizeFileName(fileName) {
-  return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 }
 
 sanitizeGpxFileNames();

--- a/scripts/sanitize-gpx.js
+++ b/scripts/sanitize-gpx.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const gpxDir = path.join(__dirname, '../gpx-files');
+
+function sanitizeGpxFileNames() {
+  fs.readdir(gpxDir, (err, files) => {
+    if (err) {
+      console.error('Error reading GPX directory:', err);
+      return;
+    }
+
+    files.forEach((file) => {
+      if (path.extname(file) === '.gpx') {
+        const sanitizedFileName = sanitizeFileName(path.basename(file, '.gpx')) + '.gpx';
+        const oldFilePath = path.join(gpxDir, file);
+        const newFilePath = path.join(gpxDir, sanitizedFileName);
+
+        if (oldFilePath !== newFilePath) {
+          fs.rename(oldFilePath, newFilePath, (err) => {
+            if (err) {
+              console.error('Error renaming file:', err);
+            } else {
+              console.log(`Renamed ${file} to ${sanitizedFileName}`);
+            }
+          });
+        }
+      }
+    });
+  });
+}
+
+function sanitizeFileName(fileName) {
+  return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+}
+
+module.exports = { sanitizeGpxFileNames };


### PR DESCRIPTION
Separate `sanitizeGpxFileNames` from `processGpxFiles` into different JavaScript files and update GitHub Actions workflows.

* **New File**: Add `scripts/sanitize-gpx.js` to contain the `sanitizeGpxFileNames` function.
* **Process GPX Script**: Modify `scripts/process-gpx.js` to remove the `sanitizeGpxFileNames` function and import it from `scripts/sanitize-gpx.js`.
* **GitHub Actions**: Update `.github/workflows/deploy.yml` and `.github/workflows/verify-pr.yml` to run `scripts/sanitize-gpx.js` before `scripts/process-gpx.js`.
* **Documentation**: Update `README.md` to reflect the separation of `sanitizeGpxFileNames` and `processGpxFiles` into separate scripts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/18?shareId=6f2b3c28-97f9-4c92-8055-110e9e7639a8).