### PR TITLE
feat: Add popup with download link when clicking on a trace

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -18,11 +18,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const coordinates = trace.coordinates.map(coord => [coord.lat, coord.lon]);
         const polyline = L.polyline(coordinates, { color: getColor(trace.category) }).addTo(map);
 
-        polyline.on('click', () => {
-          const link = document.createElement('a');
-          link.href = `gpx-files/${trace.name}.gpx`;
-          link.download = `${trace.name}.gpx`;
-          link.click();
+        polyline.on('click', (e) => {
+          const popupContent = `
+            <div>
+              <strong>${trace.name}</strong><br>
+              <a href="gpx-files/${trace.name}.gpx" download="${trace.name}.gpx">Download GPX</a>
+            </div>
+          `;
+          const popup = L.popup()
+            .setLatLng(e.latlng)
+            .setContent(popupContent)
+            .openOn(map);
+          polyline.bindPopup(popup);
         });
 
         polyline.on('mouseover', (e) => {


### PR DESCRIPTION
Fixes #21

Add a popup with a download link when clicking on a trace.

* Modify the `polyline.on('click', ...)` event handler to display a popup with a download link instead of directly triggering the download.
* Create a new `L.popup()` instance within the `polyline.on('click', ...)` event handler and set its content to an anchor element with the download link.
* Bind the new popup to the polyline and open it at the clicked location.
* Add the name of the trace above the download link in the popup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/22?shareId=89846d0e-8357-46aa-9180-34a67bdf5e69).