### PR TITLE
Fix download link in popup to use sanitized name

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const popupContent = `
             <div>
               <strong>${trace.name}</strong><br>
-              <a href="gpx-files/${trace.name}.gpx" download>Download GPX</a>
+              <a href="gpx-files/${trace.sanitizedName}.gpx" download>Download GPX</a>
             </div>
           `;
           const popup = L.popup()

--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -35,6 +35,7 @@ function processGpxFiles() {
 
             const trace = {
               name: path.basename(file, '.gpx'),
+              sanitizedName: sanitizeFileName(path.basename(file, '.gpx')),
               category: getCategory(path.basename(file, '.gpx')),
               coordinates: getCoordinates(result.gpx.trk[0].trkseg[0].trkpt)
             };


### PR DESCRIPTION
Update the download link in the popup to use the sanitized trace name.

* Modify `scripts/map.js` to use `trace.sanitizedName` instead of `trace.name` in the download link.
* Add a new property `sanitizedName` to the `trace` object in `scripts/process-gpx.js`.
* Set the `sanitizedName` property to the sanitized file name in `scripts/process-gpx.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/24?shareId=372ca6ed-d029-493b-bee3-b094dd6e296f).