### PR TITLE
Fix CI error related to TypeError in jwa/index.js

### DIFF
--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -9,7 +9,7 @@ const outputFilePath = path.join(__dirname, '../data/traces.json');
 const categories = ['sec', 'inonde', 'boueux'];
 
 const auth = new google.auth.GoogleAuth({
-  keyFile: path.join(__dirname, '../credentials.json'),
+  credentials: JSON.parse(process.env.GOOGLE_DRIVE_CREDENTIALS),
   scopes: ['https://www.googleapis.com/auth/drive.readonly']
 });
 


### PR DESCRIPTION
Update `scripts/process-gpx.js` to fix CI error related to `GOOGLE_DRIVE_CREDENTIALS`.

* Replace `keyFile` property with `credentials` property in the `google.auth.GoogleAuth` object.
* Parse `GOOGLE_DRIVE_CREDENTIALS` environment variable as JSON.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/31?shareId=f7aa041e-4134-42a0-812b-45cb2e9880fb).