### PR TITLE
Fix ENOENT error for missing traces.json file

### DIFF
--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -71,6 +71,8 @@ async function processGpxFiles() {
 
       traces.push(trace);
 
+      ensureDataDirectoryExists();
+
       fs.writeFile(outputFilePath, JSON.stringify({ traces }, null, 2), (err) => {
         if (err) {
           console.error('Error writing output file:', err);
@@ -96,6 +98,13 @@ function getCoordinates(trkpts) {
     lat: parseFloat(trkpt.$.lat),
     lon: parseFloat(trkpt.$.lon)
   }));
+}
+
+function ensureDataDirectoryExists() {
+  const dataDir = path.join(__dirname, '../data');
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir);
+  }
 }
 
 processGpxFiles();


### PR DESCRIPTION
Fix the 'ENOENT: no such file or directory' error for the path '/home/runner/work/gpx-traces-website/gpx-traces-website/data/traces.json'.

* Add a function `ensureDataDirectoryExists` to check and create the `data` directory if it does not exist.
* Call `ensureDataDirectoryExists` before writing the `traces.json` file in `scripts/process-gpx.js`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/32?shareId=88729c87-84ea-4f08-bef7-3d6eee2ef41c).