### PR TITLE
Improve filters responsiveness on index.html for smartphones

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -46,3 +46,10 @@ main {
 .leaflet-interactive {
   padding: 10px;
 }
+
+/* Media query for smaller screens */
+@media (max-width: 600px) {
+  #filters {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
Add media query to make the filters div responsive on smaller screens.

* Add media query for screens with a max-width of 600px
* Use `flex-wrap: wrap;` to allow filters to wrap onto multiple lines on smaller screens

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/37?shareId=b9dc76f5-e099-4a16-a5e4-cd21ef33e818).