### PR TITLE
Use diacritics library to sanitize GPX file names

### DIFF
--- a/scripts/sanitize-gpx.js
+++ b/scripts/sanitize-gpx.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const diacritics = require('diacritics'); // Import the diacritics library
 
 const gpxDir = path.join(__dirname, '../gpx-files');
 
@@ -32,7 +33,9 @@ function sanitizeGpxFileNames() {
 }
 
 function sanitizeFileName(fileName) {
-  return fileName.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+  return diacritics.remove(fileName) // Use diacritics library to remove accents
+    .replace(/[^a-z0-9]/gi, '_')
+    .toLowerCase();
 }
 
 module.exports = { sanitizeGpxFileNames, sanitizeFileName };

--- a/tests/sanitize-gpx.test.js
+++ b/tests/sanitize-gpx.test.js
@@ -19,4 +19,21 @@ describe('sanitizeGpxFileNames', () => {
       expect(sanitizedFilename).toBe(expectedSanitizedFilenames[index]);
     });
   });
+
+  test('sanitizes filenames by replacing accented characters with unaccented equivalents', () => {
+    const filenames = [
+      'éèàçôöîïùûüâäêëÿñ.gpx',
+      'ÉÈÀÇÔÖÎÏÙÛÜÂÄÊËŸÑ.gpx'
+    ];
+
+    const expectedSanitizedFilenames = [
+      'eeacooiiuuuuaaeeeyn.gpx',
+      'eeacooiiuuuuaaeeeyn.gpx'
+    ];
+
+    filenames.forEach((filename, index) => {
+      const sanitizedFilename = sanitizeFileName(filename.replace('.gpx', '')) + '.gpx';
+      expect(sanitizedFilename).toBe(expectedSanitizedFilenames[index]);
+    });
+  });
 });


### PR DESCRIPTION
Update `sanitizeFileName` function to transform accented characters into unaccented equivalents.

* Import the `diacritics` library in `scripts/sanitize-gpx.js`.
* Update `sanitizeFileName` function in `scripts/sanitize-gpx.js` to use the `diacritics` library to remove accents and replace non-alphanumeric characters with underscores.
* Add test cases in `tests/sanitize-gpx.test.js` to verify that accented characters are replaced with unaccented equivalents using the `diacritics` library.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/44?shareId=87cbc920-12a2-459b-8f4b-f307745513de).