### PR TITLE
Fix map.test.js to create data/traces.json before running tests

### DIFF
--- a/tests/map.test.js
+++ b/tests/map.test.js
@@ -1,4 +1,9 @@
+process.env.NODE_ENV = 'test';
+
 const { getColor, getWeight } = require('../scripts/map');
+const { processGpxFiles } = require('../scripts/process-gpx');
+const fs = require('fs');
+const path = require('path');
 
 describe('getColor', () => {
   test('returns correct color for parcours category', () => {
@@ -41,5 +46,80 @@ describe('getWeight', () => {
 
   test('returns correct weight for autres category', () => {
     expect(getWeight('autres')).toBe(8);
+  });
+});
+
+describe('processGpxFiles', () => {
+  const gpxFilesDir = path.join(__dirname, '../gpx-files');
+  const outputFilePath = path.join(__dirname, '../data/traces.json');
+
+  beforeAll(() => {
+    // Ensure the gpx-files directory exists
+    if (!fs.existsSync(gpxFilesDir)) {
+      fs.mkdirSync(gpxFilesDir);
+    }
+
+    // Create sample GPX files for testing
+    const sampleGpxContent1 = `
+      <gpx>
+        <trk>
+          <name>Sample Track</name>
+          <trkseg>
+            <trkpt lat="47.325" lon="-1.736"></trkpt>
+            <trkpt lat="47.326" lon="-1.737"></trkpt>
+          </trkseg>
+        </trk>
+      </gpx>
+    `;
+    fs.writeFileSync(path.join(gpxFilesDir, 'Sample Track.gpx'), sampleGpxContent1);
+
+    const sampleGpxContent2 = `
+      <gpx>
+        <trk>
+          <name>Chemin boueux - La valinière</name>
+          <trkseg>
+            <trkpt lat="47.325" lon="-1.736"></trkpt>
+            <trkpt lat="47.326" lon="-1.737"></trkpt>
+          </trkseg>
+        </trk>
+      </gpx>
+    `;
+    fs.writeFileSync(path.join(gpxFilesDir, 'Chemin boueux - La valinière.gpx'), sampleGpxContent2);
+  });
+
+  afterAll(() => {
+    // Clean up the gpx-files directory and traces.json file
+    fs.readdirSync(gpxFilesDir).forEach((file) => {
+      fs.unlinkSync(path.join(gpxFilesDir, file));
+    });
+    if (fs.existsSync(outputFilePath)) {
+      fs.unlinkSync(outputFilePath);
+    }
+  });
+
+  test('processes GPX files and creates traces.json', async () => {
+    await processGpxFiles();
+
+    // Check the traces.json file
+    const tracesJson = JSON.parse(fs.readFileSync(outputFilePath, 'utf8'));
+    expect(tracesJson.traces).toHaveLength(2);
+
+    // Check the first trace
+    expect(tracesJson.traces[0].name).toBe('Sample Track');
+    expect(tracesJson.traces[0].sanitizedName).toBe('sample_track');
+    expect(tracesJson.traces[0].category).toBe('autres');
+    expect(tracesJson.traces[0].coordinates).toEqual([
+      { lat: 47.325, lon: -1.736 },
+      { lat: 47.326, lon: -1.737 }
+    ]);
+
+    // Check the second trace
+    expect(tracesJson.traces[1].name).toBe('Chemin boueux - La valinière');
+    expect(tracesJson.traces[1].sanitizedName).toBe('chemin_boueux___la_valiniere');
+    expect(tracesJson.traces[1].category).toBe('chemin_boueux');
+    expect(tracesJson.traces[1].coordinates).toEqual([
+      { lat: 47.325, lon: -1.736 },
+      { lat: 47.326, lon: -1.737 }
+    ]);
   });
 });


### PR DESCRIPTION
Add logic to create `data/traces.json` in `map.test.js` before running tests.

* Set `NODE_ENV` to `test` before running tests.
* Add a require call to `scripts/process-gpx.js` to generate `data/traces.json`.
* Create two sample GPX files in the `gpx-files/` directory for testing.
* Add a new test suite to process GPX files and create `data/traces.json`.
* Clean up the `gpx-files` directory and `traces.json` file after tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/46?shareId=250d138b-a6e7-466e-85b9-15335aa066a2).