### PR TITLE
Update GPX file storage for tests

### DIFF
--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -6,6 +6,7 @@ const { sanitizeFileName } = require('./sanitize-gpx');
 
 const outputFilePath = path.join(__dirname, '../data/traces.json');
 const gpxFilesDir = path.join(__dirname, '../gpx-files');
+const exampleGpxFilesDir = path.join(__dirname, '../example-gpx');
 
 const categories = ['parcours', 'chemin_boueux', 'chemin_inondable', 'danger'];
 
@@ -21,9 +22,11 @@ const drive = google.drive({
 
 async function listGpxFiles() {
   if (process.env.NODE_ENV === 'test') {
-    return fs.readdirSync(gpxFilesDir)
+    const exampleFiles = fs.readdirSync(exampleGpxFilesDir)
       .filter(file => path.extname(file) === '.gpx')
       .map(file => ({ name: file }));
+    console.log('All files found:', exampleFiles);
+    return exampleFiles;
   } else {
     const folderId = process.env.GOOGLE_DRIVE_FOLDER_ID;
     const res = await drive.files.list({
@@ -37,8 +40,11 @@ async function listGpxFiles() {
 
 async function downloadGpxFile(fileId, fileName) {
   if (process.env.NODE_ENV === 'test') {
-    const filePath = path.join(gpxFilesDir, fileName);
-    return fs.readFileSync(filePath, 'utf8');
+    const srcPath = path.join(exampleGpxFilesDir, fileName);
+    const sanitizedFileName = sanitizeFileName(path.basename(fileName, '.gpx')) + '.gpx';
+    const destPath = path.join(gpxFilesDir, sanitizedFileName);
+    fs.copyFileSync(srcPath, destPath);
+    return fs.readFileSync(destPath, 'utf8');
   } else {
     const res = await drive.files.get({
       fileId: fileId,

--- a/tests/end-to-end.test.js
+++ b/tests/end-to-end.test.js
@@ -6,13 +6,14 @@ const fs = require('fs');
 const path = require('path');
 
 describe('End-to-end filename processing', () => {
+  const exampleGpxFilesDir = path.join(__dirname, '../example-gpx');
   const gpxFilesDir = path.join(__dirname, '../gpx-files');
   const outputFilePath = path.join(__dirname, '../data/traces.json');
 
   beforeAll(() => {
-    // Ensure the gpx-files directory exists
-    if (!fs.existsSync(gpxFilesDir)) {
-      fs.mkdirSync(gpxFilesDir);
+    // Ensure the example-gpx directory exists
+    if (!fs.existsSync(exampleGpxFilesDir)) {
+      fs.mkdirSync(exampleGpxFilesDir);
     }
 
     // Create sample GPX files for testing
@@ -27,7 +28,7 @@ describe('End-to-end filename processing', () => {
         </trk>
       </gpx>
     `;
-    fs.writeFileSync(path.join(gpxFilesDir, 'Sample Track.gpx'), sampleGpxContent1);
+    fs.writeFileSync(path.join(exampleGpxFilesDir, 'Sample Track.gpx'), sampleGpxContent1);
 
     const sampleGpxContent2 = `
       <gpx>
@@ -40,13 +41,13 @@ describe('End-to-end filename processing', () => {
         </trk>
       </gpx>
     `;
-    fs.writeFileSync(path.join(gpxFilesDir, 'Chemin boueux - La valinière.gpx'), sampleGpxContent2);
+    fs.writeFileSync(path.join(exampleGpxFilesDir, 'Chemin boueux - La valinière.gpx'), sampleGpxContent2);
   });
 
   afterAll(() => {
-    // Clean up the gpx-files directory and traces.json file
-    fs.readdirSync(gpxFilesDir).forEach((file) => {
-      fs.unlinkSync(path.join(gpxFilesDir, file));
+    // Clean up the example-gpx directory and traces.json file
+    fs.readdirSync(exampleGpxFilesDir).forEach((file) => {
+      fs.unlinkSync(path.join(exampleGpxFilesDir, file));
     });
     if (fs.existsSync(outputFilePath)) {
       fs.unlinkSync(outputFilePath);

--- a/tests/map.test.js
+++ b/tests/map.test.js
@@ -50,13 +50,13 @@ describe('getWeight', () => {
 });
 
 describe('processGpxFiles', () => {
-  const gpxFilesDir = path.join(__dirname, '../gpx-files');
+  const exampleGpxFilesDir = path.join(__dirname, '../example-gpx');
   const outputFilePath = path.join(__dirname, '../data/traces.json');
 
   beforeAll(() => {
-    // Ensure the gpx-files directory exists
-    if (!fs.existsSync(gpxFilesDir)) {
-      fs.mkdirSync(gpxFilesDir);
+    // Ensure the example-gpx directory exists
+    if (!fs.existsSync(exampleGpxFilesDir)) {
+      fs.mkdirSync(exampleGpxFilesDir);
     }
 
     // Create sample GPX files for testing
@@ -71,7 +71,7 @@ describe('processGpxFiles', () => {
         </trk>
       </gpx>
     `;
-    fs.writeFileSync(path.join(gpxFilesDir, 'Sample Track.gpx'), sampleGpxContent1);
+    fs.writeFileSync(path.join(exampleGpxFilesDir, 'Sample Track.gpx'), sampleGpxContent1);
 
     const sampleGpxContent2 = `
       <gpx>
@@ -84,13 +84,13 @@ describe('processGpxFiles', () => {
         </trk>
       </gpx>
     `;
-    fs.writeFileSync(path.join(gpxFilesDir, 'Chemin boueux - La valinière.gpx'), sampleGpxContent2);
+    fs.writeFileSync(path.join(exampleGpxFilesDir, 'Chemin boueux - La valinière.gpx'), sampleGpxContent2);
   });
 
   afterAll(() => {
-    // Clean up the gpx-files directory and traces.json file
-    fs.readdirSync(gpxFilesDir).forEach((file) => {
-      fs.unlinkSync(path.join(gpxFilesDir, file));
+    // Clean up the example-gpx directory and traces.json file
+    fs.readdirSync(exampleGpxFilesDir).forEach((file) => {
+      fs.unlinkSync(path.join(exampleGpxFilesDir, file));
     });
     if (fs.existsSync(outputFilePath)) {
       fs.unlinkSync(outputFilePath);


### PR DESCRIPTION
Update test files to store example GPX files in a separate directory named `example-gpx/`.

* **tests/end-to-end.test.js**
  - Add `exampleGpxFilesDir` variable to point to the `example-gpx` directory.
  - Update `beforeAll` and `afterAll` hooks to use `exampleGpxFilesDir` for creating and cleaning up sample GPX files.

* **tests/map.test.js**
  - Add `exampleGpxFilesDir` variable to point to the `example-gpx` directory.
  - Update `beforeAll` and `afterAll` hooks to use `exampleGpxFilesDir` for creating and cleaning up sample GPX files.

* **scripts/process-gpx.js**
  - Add `exampleGpxFilesDir` variable to point to the `example-gpx` directory.
  - Update `listGpxFiles` function to read files from `exampleGpxFilesDir` in test environment.
  - Update `downloadGpxFile` function to copy files from `exampleGpxFilesDir` to `gpxFilesDir` and sanitize filenames in test environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/47?shareId=dfc05fc0-0027-4e23-8a9e-4ebb03a97759).