### PR TITLE
Fix file reading to occur during processGpxFiles()

### DIFF
--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -45,7 +45,7 @@ async function downloadGpxFile(fileId, fileName) {
     const destPath = path.join(gpxFilesDir, sanitizedFileName);
     ensureGpxFilesDirectoryExists();
     fs.copyFileSync(srcPath, destPath);
-    return fs.readFileSync(destPath, 'utf8');
+    return destPath;
   } else {
     const res = await drive.files.get({
       fileId: fileId,
@@ -62,7 +62,7 @@ async function downloadGpxFile(fileId, fileName) {
         const filePath = path.join(gpxFilesDir, sanitizedFileName);
         ensureGpxFilesDirectoryExists();
         fs.writeFileSync(filePath, data);
-        resolve(data);
+        resolve(filePath);
       });
       res.data.on('error', err => {
         reject(err);
@@ -85,7 +85,8 @@ async function processGpxFiles() {
   }
 
   for (const file of files) {
-    const gpxData = await downloadGpxFile(file.id, file.name);
+    const filePath = await downloadGpxFile(file.id, file.name);
+    const gpxData = fs.readFileSync(filePath, 'utf8');
     const sanitizedFileName = sanitizeFileName(path.basename(file.name, '.gpx')) + '.gpx';
 
     xml2js.parseString(gpxData, (err, result) => {


### PR DESCRIPTION
Modify `downloadGpxFile()` to return the file path instead of the file content.

Update `processGpxFiles()` to read the file content directly from the returned file path.
* Read the file content using `fs.readFileSync(filePath, 'utf8')` in `processGpxFiles()`
* Remove reading file content from `downloadGpxFile()`
* Ensure `downloadGpxFile()` resolves with the file path

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/48?shareId=f9dae6c3-e3ff-48cd-b6a9-e1e540ffe686).