### PR TITLE
Fix CI error for tests

### DIFF
--- a/scripts/process-gpx.js
+++ b/scripts/process-gpx.js
@@ -106,18 +106,10 @@ async function processGpxFiles() {
       };
 
       traces.push(trace);
-
-      ensureDataDirectoryExists();
-
-      fs.writeFile(outputFilePath, JSON.stringify({ traces }, null, 2), (err) => {
-        if (err) {
-          console.error('Error writing output file:', err);
-          process.exit(1);
-        }
-        console.log(`Successfully processed and saved trace: ${trace.name}`);
-      });
     });
   }
+
+  writeTracesJson(traces);
 
   // Check if all trace files exist in the gpx-files directory
   traces.forEach(trace => {
@@ -125,6 +117,20 @@ async function processGpxFiles() {
     if (!fs.existsSync(filePath)) {
       console.error(`File not found: ${filePath}`);
       process.exit(1);
+    }
+  });
+}
+
+function writeTracesJson(traces) {
+  ensureDataDirectoryExists();
+  fs.writeFile(outputFilePath, JSON.stringify({ traces }, null, 2), (err) => {
+    if (err) {
+      console.error('Error writing output file:', err);
+      process.exit(1);
+    }
+    console.log('Successfully wrote traces.json file');
+    if (process.env.NODE_ENV === 'test') {
+      console.log('traces content before JSON', traces)
     }
   });
 }


### PR DESCRIPTION
Fix the end-to-end filename processing test to correctly parse the JSON input without a syntax error.

* **scripts/process-gpx.js**
  - Move the `fs.writeFile` call outside the `xml2js.parseString` callback to write the `traces.json` file only once after processing all GPX files.
  - Add a new function `writeTracesJson` to handle writing the `traces.json` file.
  - Call the `writeTracesJson` function after the loop that processes all GPX files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/49?shareId=f2d45fe5-67fe-4f63-8281-0f1fdde717b0).