### PR TITLE
Update unit tests to use Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ To create the `GOOGLE_DRIVE_FOLDER_ID` secret in your GitHub repository, follow 
 
 This will create the `GOOGLE_DRIVE_FOLDER_ID` secret in your repository, which will be used by the GitHub Actions workflows to specify the folder containing the GPX files.
 
+## Creating the GOOGLE_DRIVE_FOLDER_ID_TEST Secret
+
+To create the `GOOGLE_DRIVE_FOLDER_ID_TEST` secret in your GitHub repository, follow these steps:
+
+1. Go to your repository on GitHub.
+2. Click on the "Settings" tab.
+3. In the left sidebar, click on "Secrets".
+4. Click on the "New repository secret" button.
+5. In the "Name" field, enter `GOOGLE_DRIVE_FOLDER_ID_TEST`.
+6. In the "Value" field, enter the ID of the specific test folder on Google Drive.
+7. Click on the "Add secret" button.
+
+This will create the `GOOGLE_DRIVE_FOLDER_ID_TEST` secret in your repository, which will be used by the GitHub Actions workflows to specify the test folder containing the GPX files.
+
 ## Finding the ID of the GOOGLE_DRIVE_FOLDER_ID
 
 To find the ID of the specific folder on Google Drive, follow these steps:
@@ -179,18 +193,13 @@ To run the script locally while defining the `GOOGLE_DRIVE_FOLDER_ID` and `GOOGL
 
 This will process the GPX files from the specified Google Drive folder and update the `data/traces.json` file.
 
-## Running Unit Tests with Local GPX Files
+## Creating GPX Files for Unit Tests and Storing Them on Google Drive
 
-To run the unit tests using local GPX files stored in the `gpx-files` directory, follow these steps:
+To create the correct GPX files for unit tests and store them manually on the proper Google Drive, follow these steps:
 
-1. Ensure the `gpx-files` directory contains the necessary GPX files for testing.
-2. Set the `NODE_ENV` environment variable to `test` before running the tests:
-   ```sh
-   export NODE_ENV=test
-   ```
-3. Run the tests using the following command:
-   ```sh
-   npm test
-   ```
+1. Create the GPX files with the required content. Ensure the file names include the category ("parcours", "chemin_boueux", "chemin_inondable", "danger", "autres") to map them correctly.
+2. Upload the GPX files to the designated test folder on Google Drive.
+3. Find the ID of the test folder on Google Drive by navigating to the folder and copying the long string of characters after `folders/` in the URL.
+4. Create the `GOOGLE_DRIVE_FOLDER_ID_TEST` secret in your GitHub repository with the test folder ID as the value. Refer to the instructions in the `README.md` file for creating secrets.
 
-This will use the local GPX files from the `gpx-files` directory instead of downloading them from Google Drive during the unit tests.
+

--- a/tests/process-gpx.test.js
+++ b/tests/process-gpx.test.js
@@ -1,6 +1,9 @@
 process.env.NODE_ENV = 'test';
 
-const { getCategory, getCoordinates } = require('../scripts/process-gpx');
+const { getCategory, getCoordinates, processGpxFiles } = require('../scripts/process-gpx');
+const { google } = require('googleapis');
+const fs = require('fs');
+const path = require('path');
 
 describe('getCategory', () => {
   test('returns correct category for parcours', () => {
@@ -35,5 +38,58 @@ describe('getCoordinates', () => {
       { lat: 47.326, lon: -1.737 }
     ];
     expect(getCoordinates(trkpts)).toEqual(expectedCoordinates);
+  });
+});
+
+describe('Google Drive integration', () => {
+  const gpxFilesDir = path.join(__dirname, '../gpx-files');
+  const outputFilePath = path.join(__dirname, '../data/traces.json');
+
+  beforeAll(async () => {
+    // Set up Google Drive credentials
+    const credentials = JSON.parse(process.env.GOOGLE_DRIVE_CREDENTIALS);
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: ['https://www.googleapis.com/auth/drive.readonly']
+    });
+    google.options({ auth });
+
+    // Process GPX files
+    await processGpxFiles();
+  });
+
+  afterAll(() => {
+    // Clean up the gpx-files directory and traces.json file
+    fs.readdirSync(gpxFilesDir).forEach((file) => {
+      fs.unlinkSync(path.join(gpxFilesDir, file));
+    });
+    if (fs.existsSync(outputFilePath)) {
+      fs.unlinkSync(outputFilePath);
+    }
+  });
+
+  test('downloads and processes GPX files from Google Drive', async () => {
+    // Check the traces.json file
+    expect(fs.existsSync(outputFilePath)).toBe(true);
+    const tracesJson = JSON.parse(fs.readFileSync(outputFilePath, 'utf8'));
+    expect(tracesJson.traces).toHaveLength(2);
+
+    // Check the trace 0
+    expect(tracesJson.traces[0].name).toBe('Chemin boueux - La valinière');
+    expect(tracesJson.traces[0].sanitizedName).toBe('chemin_boueux___la_valiniere');
+    expect(tracesJson.traces[0].category).toBe('chemin_boueux');
+    expect(tracesJson.traces[0].coordinates).toEqual([
+      { lat: 47.325, lon: -1.736 },
+      { lat: 47.326, lon: -1.737 }
+    ]);
+    
+    // Check the trace 1
+    expect(tracesJson.traces[1].name).toBe('Sample Track');
+    expect(tracesJson.traces[1].sanitizedName).toBe('sample_track');
+    expect(tracesJson.traces[1].category).toBe('autres');
+    expect(tracesJson.traces[1].coordinates).toEqual([
+      { lat: 47.325, lon: -1.736 },
+      { lat: 47.326, lon: -1.737 }
+    ]);
   });
 });


### PR DESCRIPTION
Update unit tests to use Google Drive files instead of local files.

* Modify `scripts/process-gpx.js` to check `NODE_ENV` environment variable and use `GOOGLE_DRIVE_FOLDER_ID_TEST` for test folder ID.
* Update `tests/end-to-end.test.js` to set up Google Drive credentials and use Google Drive files for testing.
* Update `tests/process-gpx.test.js` to set up Google Drive credentials and use Google Drive files for testing.
* Add instructions in `README.md` for setting up `GOOGLE_DRIVE_FOLDER_ID_TEST` secret and creating GPX files for unit tests on Google Drive.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/tree/add-unit-tests?shareId=XXXX-XXXX-XXXX-XXXX).