### PR TITLE
Fix CI timeout issue by increasing test timeout and ensuring async operations are awaited

### DIFF
--- a/tests/end-to-end.test.js
+++ b/tests/end-to-end.test.js
@@ -1,3 +1,5 @@
+jest.setTimeout(10000);
+
 process.env.NODE_ENV = 'test';
 
 const { processGpxFiles } = require('../scripts/process-gpx');
@@ -33,7 +35,7 @@ describe('End-to-end filename processing', () => {
     }
   });
 
-  test('sanitizes, categorizes, processes, and displays the filename correctly', async () => {
+  test('sanitizes, categorizes, processes, and displays the filename correctly', async (done) => {
     // Check the sanitized file names
     const sanitizedFileName0 = 'chemin_boueux___la_valiniere.gpx';
     const sanitizedFileName1 = 'sample_track.gpx';
@@ -62,5 +64,7 @@ describe('End-to-end filename processing', () => {
       { lat: 47.325, lon: -1.736 },
       { lat: 47.326, lon: -1.737 }
     ]);
+
+    done();
   });
 });

--- a/tests/process-gpx.test.js
+++ b/tests/process-gpx.test.js
@@ -1,3 +1,5 @@
+jest.setTimeout(10000);
+
 process.env.NODE_ENV = 'test';
 
 const { getCategory, getCoordinates, processGpxFiles } = require('../scripts/process-gpx');


### PR DESCRIPTION
Fix the issue "Cannot log after tests are done. Did you forget to wait for something async in your test?" in the CI.

* **tests/end-to-end.test.js**
  - Add `jest.setTimeout(10000)` to increase the timeout for long-running tests.
  - Add `done` callback to the test function to ensure it is asynchronous.

* **tests/process-gpx.test.js**
  - Add `jest.setTimeout(10000)` to increase the timeout for long-running tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/52?shareId=9df230bb-eda1-4cfa-856d-3451870f539e).