### PR TITLE
Refactor map utility functions to separate file

### DIFF
--- a/scripts/map-utils.js
+++ b/scripts/map-utils.js
@@ -1,0 +1,29 @@
+function getColor(category) {
+  if (category === 'parcours') {
+    return '#35978f';
+  } else if (category === 'chemin_boueux') {
+    return '#542788';
+  } else if (category === 'chemin_inondable') {
+    return '#fdb863';
+  } else if (category === 'danger') {
+    return '#b30000';
+  } else {
+    return 'pink';
+  }
+}
+
+function getWeight(category) {
+  if (category === 'parcours') {
+    return 8;
+  } else if (category === 'chemin_boueux') {
+    return 10;
+  } else if (category === 'chemin_inondable') {
+    return 10;
+  } else if (category === 'danger') {
+    return 11;
+  } else {
+    return 8;
+  }
+}
+
+export { getColor, getWeight };

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,5 +1,6 @@
 import L from 'leaflet';
 import xml2js from 'xml2js';
+import { getColor, getWeight } from './map-utils';
 
 let gpsMarker = null;
 
@@ -80,34 +81,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       });
     });
-
-  function getColor(category) {
-    if (category === 'parcours') {
-      return '#35978f';
-    } else if (category === 'chemin_boueux') {
-      return '#542788';
-    } else if (category === 'chemin_inondable') {
-      return '#fdb863';
-    } else if (category === 'danger') {
-      return '#b30000';
-    } else {
-      return 'pink';
-    }
-  }
-
-  function getWeight(category) {
-    if (category === 'parcours') {
-      return 8;
-    } else if (category === 'chemin_boueux') {
-      return 10;
-    } else if (category === 'chemin_inondable') {
-      return 10;
-    } else if (category === 'danger') {
-      return 11;
-    } else {
-      return 8;
-    }
-  }
 
   function addCurrentPositionToMap(position) {
     const { latitude, longitude } = position.coords;

--- a/tests/map-utils.test.js
+++ b/tests/map-utils.test.js
@@ -1,6 +1,6 @@
 process.env.NODE_ENV = 'test';
 
-const { getColor, getWeight } = require('../scripts/map');
+const { getColor, getWeight } = require('../scripts/map-utils');
 const fs = require('fs');
 const path = require('path');
 
@@ -47,4 +47,3 @@ describe('getWeight', () => {
     expect(getWeight('autres')).toBe(8);
   });
 });
-


### PR DESCRIPTION
Move utility functions to a separate file and update imports and tests accordingly.

* Add `scripts/map-utils.js` to define and export `getColor` and `getWeight` functions.
* Modify `scripts/map.js` to import `getColor` and `getWeight` from `./map-utils` and remove their definitions.
* Rename `tests/map.test.js` to `tests/map-utils.test.js` and update imports to use `../scripts/map-utils`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/56?shareId=46e76b7f-706b-454d-b0bf-91f82d837cda).