### PR TITLE
Fix webpack config to use correct gpxFilesDir

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,10 @@
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const gpxFilesDir = process.env.GPX_FILES_DIR || 'gpx-files-real-data';
 
 module.exports = {
   entry: './scripts/map.js',
@@ -32,7 +37,7 @@ module.exports = {
         { from: 'index.html', to: 'index.html' },
         { from: 'styles.css', to: 'styles.css' },
         { from: 'data/traces.json', to: 'data/traces.json' },
-        { from: 'gpx-files', to: 'gpx-files' }
+        { from: gpxFilesDir, to: gpxFilesDir }
       ]
     })
   ],


### PR DESCRIPTION
Update `webpack.config.js` to use the `gpxFilesDir` environment variable.

* Import `dotenv` package to load environment variables.
* Add `gpxFilesDir` variable to get the value from environment variables.
* Update `CopyWebpackPlugin` to use `gpxFilesDir` for copying GPX files.
* Update `CopyWebpackPlugin` to use `gpxFilesDir` for the "to:" field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/58?shareId=f1711b88-34b6-4741-9d5e-4350b20bedb7).