### PR TITLE
Update deprecated npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
   "author": "statnmap",
   "license": "MIT",
   "dependencies": {
+    "@eslint/config-array": "^0.19.1",
+    "@eslint/object-schema": "^2.1.5",
     "braces": "^3.0.3",
     "diacritics": "^1.3.0",
+    "glob": "^9.0.0",
     "googleapis": "^144.0.0",
     "leaflet": "^1.7.1",
+    "rimraf": "^4.0.0",
     "uuid": "^7.0.3",
     "xml2js": "^0.6.2"
   },
@@ -30,15 +34,15 @@
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^5.0.1",
     "dotenv": "^16.4.7",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^8.0.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.0.6",
+    "prettier": "^2.0.0",
     "style-loader": "^2.0.0",
     "webpack": "^5.24.2",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^5.2.0",
-    "eslint": "^8.0.0",
-    "prettier": "^2.0.0",
-    "eslint-config-prettier": "^8.0.0",
-    "eslint-plugin-prettier": "^4.0.0"
+    "webpack-dev-server": "^5.2.0"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Update deprecated npm packages in `package.json`.

* Add `@eslint/config-array` and `@eslint/object-schema` dependencies.
* Add `glob` and `rimraf` dependencies with updated versions.
* Add `eslint`, `eslint-config-prettier`, `eslint-plugin-prettier`, and `prettier` dependencies.
* Remove old `eslint`, `prettier`, `eslint-config-prettier`, and `eslint-plugin-prettier` dependencies.
* Remove `webpack-dev-server` and re-add it with the same version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/60?shareId=ec14b7a0-bca0-422b-94b0-ebacac9a9092).