### PR TITLE
Update traces file path to separate for real-data and unit tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
       GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
       GOOGLE_DRIVE_FOLDER_ID_TEST: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID_TEST }}
       GPX_FILES_DIR: gpx-files-real-data
+      TRACES_FILE_PATH: traces-real/traces.json
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,6 +12,7 @@ jobs:
       GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
       GOOGLE_DRIVE_FOLDER_ID_TEST: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID_TEST }}
       GPX_FILES_DIR: gpx-files-real-data
+      TRACES_FILE_PATH: traces-real/traces.json
 
     steps:
       - name: Checkout repository

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -7,6 +7,7 @@ import { getColor, getWeight } from './map-utils';
  * @type {string}
  */
 const gpxFilesDir = process.env.GPX_FILES_DIR || 'gpx-files-real-data';
+const tracesFilePath = process.env.TRACES_FILE_PATH || 'traces-real/traces.json';
 
 let gpsMarker = null;
 
@@ -20,7 +21,7 @@ function initializeMap() {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
   }).addTo(map);
 
-  fetch('data/traces.json')
+  fetch(tracesFilePath)
     .then(response => response.json())
     .then(data => {
       const traces = data.traces;

--- a/scripts/run-process-gpx.js
+++ b/scripts/run-process-gpx.js
@@ -1,8 +1,9 @@
 const { processGpxFiles } = require('./process-gpx');
 
 const gpxFilesDir = process.env.GPX_FILES_DIR || 'gpx-files-real-data';
+const tracesFilePath = process.env.TRACES_FILE_PATH || 'traces-real/traces.json';
 
-processGpxFiles(gpxFilesDir).catch(err => {
+processGpxFiles(gpxFilesDir, tracesFilePath).catch(err => {
   console.error('Error processing GPX files:', err);
   process.exit(1);
 });

--- a/tests/end-to-end.test.js
+++ b/tests/end-to-end.test.js
@@ -9,22 +9,22 @@ const { google } = require('googleapis');
 
 describe('End-to-end filename processing', () => {
   const gpxFilesDir = path.join(__dirname, '../gpx-files-end-to-end');
-  const outputFilePath = path.join(__dirname, '../data/traces.json');
+  const tracesFilePath = path.join(__dirname, '../traces-end-to-end/traces.json');
 
   afterAll(() => {
     // Clean up the gpx-files directory and traces.json file
     fs.readdirSync(gpxFilesDir).forEach((file) => {
       fs.unlinkSync(path.join(gpxFilesDir, file));
     });
-    if (fs.existsSync(outputFilePath)) {
-      fs.unlinkSync(outputFilePath);
+    if (fs.existsSync(tracesFilePath)) {
+      fs.unlinkSync(tracesFilePath);
     }
   });
 
   test('sanitizes, categorizes, processes, and displays the filename correctly', async () => {
 
     // Process GPX files
-    await processGpxFiles(gpxFilesDir);
+    await processGpxFiles(gpxFilesDir, tracesFilePath);
 
     // Check the sanitized file names
     const sanitizedFileName0 = 'chemin_boueux___la_valiniere.gpx';
@@ -33,8 +33,8 @@ describe('End-to-end filename processing', () => {
     expect(fs.existsSync(path.join(gpxFilesDir, sanitizedFileName1))).toBe(true);
 
     // Check the traces.json file
-    expect(fs.existsSync(outputFilePath)).toBe(true);
-    const tracesJson = JSON.parse(fs.readFileSync(outputFilePath, 'utf8'));
+    expect(fs.existsSync(tracesFilePath)).toBe(true);
+    const tracesJson = JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'));
     expect(tracesJson.traces).toHaveLength(2);
 
     // Check the trace 0

--- a/tests/process-gpx.test.js
+++ b/tests/process-gpx.test.js
@@ -45,25 +45,25 @@ describe('getCoordinates', () => {
 
 describe('Google Drive integration', () => {
   const gpxFilesDir = path.join(__dirname, '../gpx-files-process');
-  const outputFilePath = path.join(__dirname, '../data/traces.json');
+  const tracesFilePath = path.join(__dirname, '../traces-process/traces.json');
 
   afterAll(() => {
     // Clean up the gpx-files directory and traces.json file
     fs.readdirSync(gpxFilesDir).forEach((file) => {
       fs.unlinkSync(path.join(gpxFilesDir, file));
     });
-    if (fs.existsSync(outputFilePath)) {
-      fs.unlinkSync(outputFilePath);
+    if (fs.existsSync(tracesFilePath)) {
+      fs.unlinkSync(tracesFilePath);
     }
   });
 
   test('downloads and processes GPX files from Google Drive', async () => {
     // Process GPX files
-    await processGpxFiles(gpxFilesDir);
+    await processGpxFiles(gpxFilesDir, tracesFilePath);
 
     // Check the traces.json file
-    expect(fs.existsSync(outputFilePath)).toBe(true);
-    const tracesJson = JSON.parse(fs.readFileSync(outputFilePath, 'utf8'));
+    expect(fs.existsSync(tracesFilePath)).toBe(true);
+    const tracesJson = JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'));
     expect(tracesJson.traces).toHaveLength(2);
 
     // Check the trace 0

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const gpxFilesDir = process.env.GPX_FILES_DIR || 'gpx-files-real-data';
+const tracesFilePath = process.env.TRACES_FILE_PATH || 'traces-real/traces.json';
 
 module.exports = {
   entry: './scripts/map.js',
@@ -36,7 +37,7 @@ module.exports = {
       patterns: [
         { from: 'index.html', to: 'index.html' },
         { from: 'styles.css', to: 'styles.css' },
-        { from: 'data/traces.json', to: 'data/traces.json' },
+        { from: tracesFilePath, to: tracesFilePath },
         { from: gpxFilesDir, to: gpxFilesDir }
       ]
     })


### PR DESCRIPTION
Update `processGpxFiles` function to accept `tracesFilePath` as a parameter and remove `outputFilePath` variable.

Update `run-process-gpx.js` to pass `tracesFilePath` as a parameter to `processGpxFiles`.

Update test files to define `tracesFilePath` and pass it as a parameter to `processGpxFiles`.

Update `webpack.config.js` to use `tracesFilePath` for `data/traces.json`.

Update `map.js` to use `tracesFilePath` instead of `data/traces.json`.

Define `TRACES_FILE_PATH` environment variable in CI files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/statnmap/gpx-traces-website/pull/63?shareId=1703bb88-3d54-421a-9d2a-357bbcbb89d1).